### PR TITLE
Added original error message to message of NueAsyncError objects.

### DIFF
--- a/lib/nue.js
+++ b/lib/nue.js
@@ -416,6 +416,9 @@ Async.prototype.makeCallback = function makeCallback(mapping, caller) {
       history = [log];
     }
     var e = new Error('An error occurred in an async call.');
+    if (err.message) {
+      e.message += '\nError message: ' + err.message;
+    }
     e.name = 'NueAsyncError';
     e.cause = cause;
     e.asyncCallHistory = history;


### PR DESCRIPTION
I'm using Nue's automatic handling of callback errors a lot in my app. I noticed, however, that the original error's message is lost when Nue handles an error from an async callback. So I slightly modified the generation of the async error object to include the original message.
